### PR TITLE
new option: allow user to choose which box should selected at spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Config file is created automatically on a first program run and stored in `~/.co
       -T, --no-titles              Turn off showing titles
       -S, --screenshot             Get screenshot and set it as a background (for WMs that do not support XShape)
       -P, --at-pointer             Place center of mosaic at pointer position.
+      -s, --selected=<N>           Select box number N at spawn. (default: 0)
       -W, --box-width=<int>        Width of the boxes (default: 200)
       -H, --box-height=<int>       Height of the boxes (default: 40)
       -i, --icon-size=<int>        Size of window icons (default: 16)

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,7 @@ static struct {
   gint center_x;
   gint center_y;
   gchar *color_file;
+  gint selected;
 } options;
 
 typedef struct {
@@ -110,6 +111,8 @@ static GOptionEntry entries [] =
     "Place center of mosaic at pointer position.", NULL },
   { "box-width", 'W', 0, G_OPTION_ARG_INT, &options.box_width,
     "Width of the boxes (default: 200)", "<int>" },
+  { "selected", 's', 0, G_OPTION_ARG_INT, &options.selected,
+    "Initially selected box", "<int>" },
   { "box-height", 'H', 0, G_OPTION_ARG_INT, &options.box_height,
     "Height of the boxes (default: 40)", "<int>" },
   { "icon-size", 'i', 0, G_OPTION_ARG_INT, &options.icon_size,
@@ -334,7 +337,9 @@ int main (int argc, char **argv)
   myown_window = GDK_WINDOW_HWND (gdk_window);
 #endif
   update_box_list ();
-  draw_mosaic (GTK_LAYOUT (layout), boxes, wsize, 0,
+
+  draw_mosaic (GTK_LAYOUT (layout), boxes, wsize,
+               options.selected >= wsize ? 0 : options.selected,
 	       options.box_width, options.box_height);
 
 #ifdef X11


### PR DESCRIPTION
Hi,

First of all, many thanks for this amazing project -- I'm using it for a pretty long time in addition with "rofi".

The reason why I'm proposing this patch is my general use-case scenario of this program. The thing is, that I'm using xwinmosaic as workspace selector, and the amount and position of the workspace is static, thus making it possible to remember the configuration and start selection from currently viewed workspace.

I could share my workspace selection script also, if you're interested.