### PR TITLE
Added option to display only windows on current desktop.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,7 @@ static struct {
   gint center_y;
   gchar *color_file;
   gint selected;
+  gboolean only_current;
 } options;
 
 typedef struct {
@@ -123,6 +124,8 @@ static GOptionEntry entries [] =
     "Set color hue offset (from 0 to 255)", "<int>" },
   { "color-file", 'F', 0, G_OPTION_ARG_FILENAME, &options.color_file,
     "Pick colors from file", "<file>" },
+  { "only-current", 'c', 0, G_OPTION_ARG_NONE, &options.only_current,
+    "Only show windows on the current workspace.", NULL},
   { NULL }
 };
 
@@ -469,7 +472,7 @@ static void update_box_list ()
       XFree (wins);
 #endif
     }
-    wins = sorted_windows_list (&myown_window, active_window, &wsize);
+    wins = sorted_windows_list (&myown_window, active_window, &wsize, options.only_current);
 #ifdef X11
     if (wins) {
       // Get PropertyNotify events from each relevant window.

--- a/src/win32_interaction.c
+++ b/src/win32_interaction.c
@@ -87,8 +87,9 @@ GdkPixbuf* get_window_icon(HWND win, guint req_width, guint req_height)
   return gicon;
 }
 
-HWND* sorted_windows_list(HWND *myown, HWND *active_win, int *nitems)
+HWND* sorted_windows_list(HWND *myown, HWND *active_win, int *nitems, gboolean only_current)
 {
+  // XXX: Ignoring only_current for now.
   WINDOWINFO pwi;
   HWND* pre_win_list = get_windows_list();
   int size = 0;

--- a/src/win32_interaction.h
+++ b/src/win32_interaction.h
@@ -17,7 +17,7 @@
 
 char *get_window_name(HWND win);
 char *get_window_class(HWND win);
-HWND* sorted_windows_list(HWND *myown, HWND *active_win, int *nitems);
+HWND* sorted_windows_list(HWND *myown, HWND *active_win, int *nitems, gboolean only_current);
 void switch_to_window(HWND win);
 GdkPixbuf* get_window_icon(HWND win, guint req_width, guint req_height);
 

--- a/src/x_interaction.h
+++ b/src/x_interaction.h
@@ -57,7 +57,7 @@ int wm_supports_ewmh ();
 char* get_window_name (Window win);
 char* get_window_class (Window win);
 int get_window_desktop (Window win);
-Window* sorted_windows_list (Window *myown, Window *active_win, int *nitems);
+Window* sorted_windows_list (Window *myown, Window *active_win, int *nitems, gboolean only_current);
 void switch_to_window (Window win);
 GdkPixbuf *get_window_icon (Window win, guint req_width, guint req_height);
 gboolean already_opened ();


### PR DESCRIPTION
Hi! I added a new option to display only the windows that are on the current desktop. I also added a filter_window() function in x_interaction.c that contains the logic for selecting which windows are to be shown; that could be used as a starting point for more complicated filtering.

As I don't have access to a Windows machine, I've not tested compiling the code in Windows yet, and the option currently does nothing in the Windows code.